### PR TITLE
Fixing travis build dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
   - julia -e 'Pkg.build("ParallelAccelerator")'
     #  - julia -e 'Pkg.clone(pwd()); Pkg.build("HPAT"); Pkg.test("HPAT")'
   - julia -e 'Pkg.clone(pwd()); Pkg.build("HPAT")'
-  - mpirun -np 2 julia examples/pi.jl
   - julia -e 'Pkg.add("HDF5")'
+  - mpirun -np 2 julia examples/pi.jl 
   - julia generate_data/generate_logistic_regression.jl --instances=10000 --path=/tmp/
   - mpirun -np 2 julia examples/logistic_regression.jl --iterations=10 --file=/tmp/logistic_regression.hdf5


### PR DESCRIPTION
In order to run `pi.jl` example HDF5 package is required. 
This PR fixes travis build by adding HDF5 package before running `pi.jl` example.